### PR TITLE
Sửa lỗi quản lý gói trong Dockerfile: thay thế yum bằng apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:17-jre-slim
-RUN yum -y update && yum install -y shadow-utils
+RUN apt-get update && apt-get install -y shadow-utils
 WORKDIR /app
 RUN useradd --shell /bin/bash app
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:17-jre-slim
-RUN apt-get update && apt-get install -y shadow-utils
+RUN apt-get update && apt-get install -y --no-install-recommends shadow && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 RUN useradd --shell /bin/bash app
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:17-jre-slim
-RUN apt-get update && apt-get install -y --no-install-recommends shadow && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends shadow-utils && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 RUN useradd --shell /bin/bash app
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:17-jre-slim
-RUN apt-get update && apt-get install -y --no-install-recommends shadow-utils && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y shadow-utils
 WORKDIR /app
 RUN useradd --shell /bin/bash app
 USER app


### PR DESCRIPTION
Sửa lỗi trong Dockerfile bằng cách thay thế lệnh `yum` bằng `apt-get` để phù hợp với hệ thống Debian-based của image openjdk:17-jre-slim.

Thay đổi này giải quyết vấn đề được báo cáo trong issue #25.

Closes #25
