### PR TITLE
注文コントローラーのNullPointerException修正

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -33,8 +33,10 @@ class OrderController(
 
 @GetMapping("/{id}")
 suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
-    // INTENTIONALLY BUGGY for agent test:
-    // getOrder may return null -> NPE at toResponse()
     val order = orderService.getOrder(id)
-    return ResponseEntity.ok(order!!.toResponse())
+    return if (order != null) {
+        ResponseEntity.ok(order.toResponse())
+    } else {
+        ResponseEntity.notFound().build()
+    }
 }


### PR DESCRIPTION
## 概要
この PR は、`GET /api/orders/{id}` エンドポイントで発生していた NullPointerException を修正します。

## 変更内容
- `OrderController.kt` の `getOrder` メソッドに null チェックを追加
- 注文が見つからない場合、404 Not Found レスポンスを返すように変更

## テスト
- [ ] 既存の単体テストが通ることを確認
- [ ] 注文が見つからない場合のテストケースを追加

## 関連 Issue
Closes #105

Closes #105
