### PR TITLE
Fix NullPointerException in OrderController.getOrder()

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -33,8 +33,10 @@ class OrderController(
 
 @GetMapping("/{id}")
 suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
-    // INTENTIONALLY BUGGY for agent test:
-    // getOrder may return null -> NPE at toResponse()
     val order = orderService.getOrder(id)
-    return ResponseEntity.ok(order!!.toResponse())
+    return if (order != null) {
+        ResponseEntity.ok(order.toResponse())
+    } else {
+        ResponseEntity.notFound().build()
+    }
 }


### PR DESCRIPTION
This PR addresses the NullPointerException occurring in the OrderController's getOrder method when an order is not found.

Changes:
- Modified the getOrder method to handle null cases
- Return a 404 Not Found response when an order doesn't exist

Fixes #108

Closes #108
