### PR TITLE
Fix NullPointerException in OrderController.getOrder()

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -33,8 +33,10 @@ class OrderController(
 
 @GetMapping("/{id}")
 suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
-    // INTENTIONALLY BUGGY for agent test:
-    // getOrder may return null -> NPE at toResponse()
     val order = orderService.getOrder(id)
-    return ResponseEntity.ok(order!!.toResponse())
+    return if (order != null) {
+        ResponseEntity.ok(order.toResponse())
+    } else {
+        ResponseEntity.notFound().build()
+    }
 }


### PR DESCRIPTION
This PR addresses the NullPointerException occurring in the OrderController when fetching an order that doesn't exist.

Changes:
- Modified `getOrder` function in `OrderController.kt` to handle null cases
- Returns a 404 Not Found response when the order is not found

Fixes #110

Closes #110
