### PR TITLE
Fix NullPointerException in OrderController.getOrder

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -33,8 +33,10 @@ class OrderController(
 
 @GetMapping("/{id}")
 suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
-    // INTENTIONALLY BUGGY for agent test:
-    // getOrder may return null -> NPE at toResponse()
     val order = orderService.getOrder(id)
-    return ResponseEntity.ok(order!!.toResponse())
+    return if (order != null) {
+        ResponseEntity.ok(order.toResponse())
+    } else {
+        ResponseEntity.notFound().build()
+    }
 }


### PR DESCRIPTION
This PR addresses the issue where GET /api/orders/{id} returns a 500 error due to a NullPointerException.

**Changes:**
- Added a null check in the `getOrder` function of `OrderController`
- Return 404 Not Found when the order doesn't exist

**Related Issue:** #112

Please review and provide feedback.

Closes #112
