### PR TITLE
Add PUT mapping for updating individual orders

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -38,3 +38,18 @@ suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
     val order = orderService.getOrder(id)
     return ResponseEntity.ok(order!!.toResponse())
 }
+
+@PutMapping("/{id}")
+suspend fun updateOrder(@PathVariable id: Long, @RequestBody orderRequest: OrderRequest): ResponseEntity<Any> {
+    return when (val result = orderService.updateOrder(id, orderRequest.toModel())) {
+        is OrderResult.Success -> ResponseEntity
+            .ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(result.order.toResponse())
+        
+        is OrderResult.BusinessFailure -> ResponseEntity
+            .status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("error" to result.reason))
+    }
+}


### PR DESCRIPTION
This PR addresses the 405 Method Not Allowed error for POST requests to /api/orders/{id} by adding a PUT mapping for updating individual orders.

Changes:
1. Added a new `updateOrder` method in the `OrderController` class.
2. Implemented PUT mapping for /api/orders/{id}.
3. Added necessary error handling and response formatting.

This change assumes that updating individual orders is a required feature and that PUT is the appropriate method for full updates. If partial updates are preferred, we may need to consider using PATCH instead.

Fixes #117

Closes #117
