### PR TITLE
Add PUT mapping for updating orders

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -38,3 +38,20 @@ suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
     val order = orderService.getOrder(id)
     return ResponseEntity.ok(order!!.toResponse())
 }
+
+@PutMapping("/{id}")
+suspend fun updateOrder(@PathVariable id: Long, @RequestBody orderRequest: OrderRequest): ResponseEntity<Any> {
+    return when (val result = orderService.updateOrder(id, orderRequest.toModel())) {
+        is OrderResult.Success -> ResponseEntity
+            .ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(result.order.toResponse())
+        is OrderResult.BusinessFailure -> ResponseEntity
+            .status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("error" to result.reason))
+        is OrderResult.NotFound -> ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .build()
+    }
+}


### PR DESCRIPTION
This PR addresses the 405 Method Not Allowed error for POST /api/orders/{id} by adding a PUT mapping to handle order updates.

Changes:
- Added a new `updateOrder` method in the OrderController with `@PutMapping("/{id}")` annotation.
- The new method handles updating existing orders using their ID.

This change assumes that:
1. Updating existing orders is a required functionality.
2. PUT is the appropriate method for full updates to an order.
3. The OrderService has or will have an `updateOrder` method to handle the business logic.

Fixes #121

Closes #121
