### PR TITLE
Add POST method support for /api/orders/{id}

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -38,3 +38,20 @@ suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
     val order = orderService.getOrder(id)
     return ResponseEntity.ok(order!!.toResponse())
 }
+
+@PostMapping("/{id}")
+suspend fun updateOrder(@PathVariable id: Long, @RequestBody orderRequest: OrderRequest): ResponseEntity<Any> {
+    return when (val result = orderService.updateOrder(id, orderRequest.toModel())) {
+        is OrderResult.Success -> ResponseEntity
+            .ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(result.order.toResponse())
+        
+        is OrderResult.BusinessFailure -> ResponseEntity
+            .status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("error" to result.reason))
+        
+        is OrderResult.NotFound -> ResponseEntity.notFound().build()
+    }
+}


### PR DESCRIPTION
This PR adds support for the POST method on the /api/orders/{id} endpoint to resolve the 405 Method Not Allowed error.

Changes:
- Added a new `updateOrder` method in the OrderController to handle POST requests for /api/orders/{id}
- Implemented basic logic for updating an existing order

Fixes #123

TODO:
- Implement proper order update logic in the OrderService
- Add appropriate error handling
- Update API documentation to reflect the new supported method

Closes #123
