### PR TITLE
Add POST mapping for updating order by ID

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -38,3 +38,18 @@ suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
     val order = orderService.getOrder(id)
     return ResponseEntity.ok(order!!.toResponse())
 }
+
+@PostMapping("/{id}")
+suspend fun updateOrder(@PathVariable id: Long, @RequestBody orderRequest: OrderRequest): ResponseEntity<Any> {
+    return when (val result = orderService.updateOrder(id, orderRequest.toModel())) {
+        is OrderResult.Success -> ResponseEntity
+            .ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(result.order.toResponse())
+        
+        is OrderResult.BusinessFailure -> ResponseEntity
+            .status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("error" to result.reason))
+    }
+}


### PR DESCRIPTION
This PR addresses the 405 Method Not Allowed error for POST requests to /api/orders/{id} by adding a new endpoint to update an existing order.

Changes:
- Added a new `updateOrder` method in `OrderController` with `@PostMapping("/{id}")` annotation
- This method handles POST requests to update an existing order by ID

Related issue: #127

TODO:
- Implement the `updateOrder` method in the `OrderService` class
- Add appropriate error handling and validation
- Update API documentation to reflect this new endpoint
- Add unit tests for the new endpoint

Please review and provide feedback on this implementation.

Closes #127
