### PR TITLE
Add POST mapping for /api/orders/{id} endpoint

### DIFF
--- a/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
+++ b/src/main/kotlin/com/loc/order_service/controller/OrderController.kt
@@ -38,3 +38,17 @@ suspend fun getOrder(@PathVariable id: Long): ResponseEntity<Any> {
     val order = orderService.getOrder(id)
     return ResponseEntity.ok(order!!.toResponse())
 }
+
+@PostMapping("/{id}")
+suspend fun updateOrder(@PathVariable id: Long, @RequestBody orderRequest: OrderRequest): ResponseEntity<Any> {
+    return when (val result = orderService.updateOrder(id, orderRequest.toModel())) {
+        is OrderResult.Success -> ResponseEntity
+            .ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(result.order.toResponse())
+        is OrderResult.BusinessFailure -> ResponseEntity
+            .status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(mapOf("error" to result.reason))
+    }
+}


### PR DESCRIPTION
This PR addresses the 405 Method Not Allowed error for POST requests to /api/orders/{id} by adding the missing POST mapping in the OrderController.

Changes:
- Added a new `updateOrder` method with `@PostMapping("/{id}")` in OrderController
- Implemented basic logic for updating an existing order

Fixes #135

Closes #135
