### PR TITLE
Fix: Add SKU code validation in OrderService.createOrder

### DIFF
--- a/src/main/kotlin/com/loc/order_service/application/service/OrderService.kt
+++ b/src/main/kotlin/com/loc/order_service/application/service/OrderService.kt
@@ -22,6 +22,10 @@ class OrderService(
 
     @Transactional
     suspend fun createOrder(order: Order): OrderResult {
+        if (order.skuCode.isBlank()) {
+            return OrderResult.BusinessFailure("Invalid SKU code: SKU code cannot be blank")
+        }
+
         log.info { "Creating order for SKU: ${order.skuCode}" }
 
         return when (inventoryService.checkStock(order.skuCode, order.quantity)) {


### PR DESCRIPTION
This PR addresses the issue of unhandled exceptions in the GlobalExceptionHandler caused by invalid SKU codes in the OrderService.createOrder method.

Changes:
- Added input validation for `skuCode` at the beginning of the `createOrder` method.
- Returns a `BusinessFailure` result instead of throwing an exception for invalid SKU codes.

This change will improve error handling and provide more meaningful feedback to API consumers when invalid SKU codes are provided.

Fixes #174

Closes #174
